### PR TITLE
現在開いているタブの全取得

### DIFF
--- a/src/test/get_tabs.js
+++ b/src/test/get_tabs.js
@@ -1,0 +1,11 @@
+let logTabs = (tabs) => {
+  console.log(tabs)
+  console.log(tabs.length)
+}
+
+// browser.queryで現在開いているタブを全取得する事ができる
+// 引数にobjectを渡すことでそのプロパティに一致するタブのみを取得できる
+let querying = browser.tabs.query({
+  // 引数に渡せるプロパティ一覧(https://developer.mozilla.org/ja/Add-ons/WebExtensions/API/tabs/query)
+})
+querying.then(logTabs)


### PR DESCRIPTION
## テスト内容
tabs.queryを用いて現在開かれているタブの全取得し，logに出力する

## できること
tabs.queryの引数に何も与えなければ開かれているタブすべて情報が入った配列が返される．
引数に与えるオブジェクトのプロパティを変更することで条件付きでタブを取得することができる．
(カレントウィンドウのタブのみを取得など)

## ファイルの読み込みについて
webextensionsではrequireもimportも使えないようです．
代わりにmanifest.jsonのbackground.scriptsの配列に追加することで複数ファイルでの開発が可能なようです．
このpull requestではmanifest.jsonには変更を加えていません．