### PR TITLE
webextensionsからタブの新規作成や削除を行うテスト

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "indent": ["error", 2, {
       "SwitchCase": 1 
     }],
-    "semi": ["error", "never"]
+    "semi": ["error", "never"],
+    "no-case-declarations": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,9 @@
   "rules": {
     "no-var": 2,
     "no-console": 0,
-    "indent": ["error", 2],
+    "indent": ["error", 2, {
+      "SwitchCase": 1 
+    }],
     "semi": ["error", "never"]
   }
 }

--- a/src/test/manage_tabs.js
+++ b/src/test/manage_tabs.js
@@ -43,10 +43,8 @@ browser.menus.onClicked.addListener(function(info, tab) {
         active: true
       })
       querying.then((tabs) => {
+        // 取得したタブのidをもとにタブを閉じる
         browser.tabs.remove(tabs[0].id).then(() => {
-          // 取得したタブのidをもとにタブを閉じる
-          removeTabs.push(tabs[0].id)
-        }).then(() => {
           console.log('removed')
         })
       })

--- a/src/test/manage_tabs.js
+++ b/src/test/manage_tabs.js
@@ -49,8 +49,7 @@ browser.menus.onClicked.addListener(function(info) {
         })
       })
       break
-    default: {
+    default:
       console.log("error")
-    }
   }
 })

--- a/src/test/manage_tabs.js
+++ b/src/test/manage_tabs.js
@@ -25,7 +25,7 @@ browser.menus.create({
   }
 })
 
-browser.menus.onClicked.addListener(function(info, tab) {
+browser.menus.onClicked.addListener(function(info) {
   switch (info.menuItemId){
     // 新しいタブの作成
     case "tab-test-create":

--- a/src/test/manage_tabs.js
+++ b/src/test/manage_tabs.js
@@ -49,5 +49,8 @@ browser.menus.onClicked.addListener(function(info, tab) {
         })
       })
       break
+    default: {
+      console.log("error")
+    }
   }
 })

--- a/src/test/manage_tabs.js
+++ b/src/test/manage_tabs.js
@@ -1,0 +1,55 @@
+// create menu
+browser.menus.create({
+  id: "tab-test-create",
+  title: "create",
+  contexts: ["tab"],
+}, () => {
+  // logging
+  if(browser.runtime.lastError){
+    console.log(browser.runtime.lastError)
+  } else{
+    console.log("menu created!")
+  }
+})
+
+browser.menus.create({
+  id: "tab-test-remove",
+  title: "remove",
+  contexts: ["tab"],
+}, () => {
+  // logging
+  if(browser.runtime.lastError){
+    console.log(browser.runtime.lastError)
+  } else{
+    console.log("menu created!")
+  }
+})
+
+browser.menus.onClicked.addListener(function(info, tab) {
+  switch (info.menuItemId){
+    // 新しいタブの作成
+    case "tab-test-create":
+      let creating = browser.tabs.create({
+        url: "http://www.google.com"
+      })
+      creating.then(() => {
+        console.log("created")
+      })
+      break
+    // アクティブなタブを閉じる
+    case "tab-test-remove":
+      // アクティブなタブの情報を取得
+      let querying = browser.tabs.query({
+        active: true
+      })
+      querying.then((tabs) => {
+        browser.tabs.remove(tabs[0].id).then(() => {
+          // 取得したタブのidをもとにタブを閉じる
+          removeTabs.push(tabs[0].id)
+        }).then(() => {
+          console.log('removed')
+        })
+      })
+      break
+  }
+})

--- a/src/test/manifest.json
+++ b/src/test/manifest.json
@@ -7,6 +7,6 @@
     "menus"
   ],
   "background": {
-    "scripts": ["main.js"]
+    "scripts": ["main.js", "manage_tabs.js"]
   }
 }


### PR DESCRIPTION
## テスト内容
タブに対するmenuにcreateとremoveを追加しそれぞれの項目をクリックした際に対応する動作を行う(タブの新規作成と削除)．

## できること
### タブの作成
`tabs.create()`の引数にurlやactiveなどのプロパティを持つオブジェクトを与えることでそのプロパティに沿ったタブを新規作成する．
3/2のミーティングでプロパティにtabのidを渡すことでタブの再作成ができるかもしれないと言いましたが，それはできませんでした．(他の実装できそうなものを見つけたのでそれは #4 の際にテストしようと思います．
### タブの削除
`tabs.remove()`の引数にtabのidを渡すことでそのidに対応するタブを閉じる事ができる
引数にintegerを与えることでそのタブを1つだけ閉じることができ，arrayで与えた場合はその要素に対応するタブをすべて閉じる事ができる．

### `switch case`のインデントチェックについて
`switch case`で以下の様に記述した場合一番最後に記述した`case`もしくは`default`のインデントについてエラーが出ます．
```javascript=
switch hoge {
  case 1:
    break
  case 2:
    break
  default:   // ここがエラー
    break    // ここがエラー
}
```
試しにdefaultの内容に{}をつけてみましたが，変わらずエラーを吐かれました