### PR TITLE
タブの再作成

### DIFF
--- a/src/test/manifest.json
+++ b/src/test/manifest.json
@@ -15,6 +15,6 @@
     "sessions"
   ],
   "background": {
-    "scripts": ["main.js", "manage_tabs.js"]
+    "scripts": ["main.js"]
   }
 }

--- a/src/test/manifest.json
+++ b/src/test/manifest.json
@@ -11,7 +11,8 @@
     "tabs",
     "menus",
     "storage",
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "sessions"
   ],
   "background": {
     "scripts": ["main.js", "manage_tabs.js"]

--- a/src/test/recreate_tab.js
+++ b/src/test/recreate_tab.js
@@ -1,0 +1,1 @@
+console.log(browser.sesstions)

--- a/src/test/recreate_tab.js
+++ b/src/test/recreate_tab.js
@@ -1,1 +1,33 @@
-console.log(browser.sesstions)
+let gettingClosedSessions = browser.sessions.getRecentlyClosed({
+  // 取得するsessionの最大数を指定する
+  // 設定しない場合はbrowser.sessions.MAX_SESSION_RESULTSに定義されている上限まで返却される(firefox DeveloperEditionでは25)
+  maxResults: 10 // 最新10件のsessionsを取得
+})
+
+// console.log(browser.sessions.MAX_SESSION_RESULTS) // 25
+
+// 最も最近閉じたsessionを1つ取得する
+// sessionにはtabの情報とwindowの両方の情報が含まれる
+// つまりタブを閉じたあとにwindowを閉じると閉じたwindowの情報が返される
+gettingClosedSessions.then((sessions) => {
+  // この段階でのsessionsには最近閉じたtabの情報とwindowの情報が最近のものから格納されている
+  // tabについてのオブジェクトにはwindowプロパティは含まれておらずtabプロパティが含まれている
+  // windowについてのオブジェクトにはtabプロパティが含まれておらずwindowプロパティが含まれている
+  console.log(sessions)
+  console.log(sessions.length)
+  return sessions
+}).then((sessions) => {
+  // tabプロパティを持つ要素のみをフィルタリング
+  return sessions.filter((element) => {
+    return (element.hasOwnProperty('tab'))
+  })
+}).then((tabs) => {
+  // フィルタリングされた配列の先頭の要素を取得
+  console.log(tabs[0].tab.sessionId)
+  return tabs[0].tab.sessionId
+}).then((id) => {
+  // sessionの復元
+  browser.sessions.restore(id)
+}).then(() => {
+  console.log('recreate')
+})


### PR DESCRIPTION
## テスト内容
一番最近閉じたタブの復元(ctrl(command) + sfhit + Tと同様の動作)を行う

## できること
### 最近閉じたsessionの取得
`sessions.getRecentlyClosed()`を用いて最近閉じたsession(ウィンドウ，タブどちらも含む)を配列で取得できる．
引数に`maxResults`を持つオブジェクトを渡すことで返却される配列の要素数の最大値を設定できる．
取得した配列のオブジェクトのプロパティにtabを持つものにフィルタリングすることで閉じたタブのみを取得できる．

### sessionの復元
取得したデータ内の`sessionId`をもとにsessionを復元する事ができる．
履歴等も同時に復元できる
タブだけでなくウィンドウの復元も可能
同じタブを復元した場合でもsessionIdは変動しているので注意が必要