### PR TITLE
CircleCI2.0への移行

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,25 +3,23 @@ version: 2
 jobs:
   build:
     docker:
-      -image: circleci/node:8.9.4-browsers
+      - image: circleci/node:8.9.4-browsers
     working_directory: ~/repo
     steps:
       - checkout
+      - restore_cache:
+          keys:
+          - dependencies-{{ checksum "package.json" }}
+          - dependencies-
       - run: npm install
-  test:
+      - save_cache:
+          paths:
+            - node_modules
+          key: dependencies-{{ checksum "package.json" }}
       - run:
-          name: run eslint
-          command: |
-            mkdir -p ~/reports
-            eslint ./src/ --format junit --output-file ~/reports/eslint.xml
-          - store_test_results:
-            path: ~/reports
-          - store_artifacts:
-            path: ~/reports
-
-workflow:
-  version: 2
-  build_and_test:
-    jobs:
-      - build
-      - test
+          name: "Run ESLint"
+          command: eslint -- --format junit -o reports/junit/eslint.xml
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,15 @@ jobs:
           keys:
           - dependencies-{{ checksum "package.json" }}
           - dependencies-
-      - run: npm install eslint
+      - run: npm install eslint --save-dev
+      - run: ./node_modules/.bin/eslint --init
       - save_cache:
           paths:
             - node_modules
           key: dependencies-{{ checksum "package.json" }}
       - run:
           name: "Run ESLint"
-          command: eslint ./src/ --format junit -o reports/junit/eslint.xml
+          command: ./node_modules/.bin/eslint ./src/ --format junit -o reports/junit/eslint.xml
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,14 @@ jobs:
           keys:
           - dependencies-{{ checksum "package.json" }}
           - dependencies-
-      - run: npm install
+      - run: npm install --global eslint
       - save_cache:
           paths:
             - node_modules
           key: dependencies-{{ checksum "package.json" }}
       - run:
           name: "Run ESLint"
-          command: eslint -- --format junit -o reports/junit/eslint.xml
+          command: eslint ./src/ --format junit -o reports/junit/eslint.xml
       - store_test_results:
           path: reports/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
           - dependencies-{{ checksum "package.json" }}
           - dependencies-
       - run: npm install eslint --save-dev
-      - run: ./node_modules/.bin/eslint --init
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      -image: node: 8.9 .4
+
+    steps:
+      - checkout
+      - run: npm install
+      - run:
+          name: run eslint
+          command: |
+            mkdir -p ./reports
+            npx eslint ./app/ --format junit --output-file ./reports/eslint.xml
+          - store_test_results:
+            path: ./reports
+          - store_artifacts:
+            path: ./reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,9 @@
 version: 2
 
 jobs:
-  build:
+  test:
     docker:
-      -image: node: 8.9 .4
-
+      -image: node: 8.9.4
     steps:
       - checkout
       - run: npm install
@@ -17,3 +16,9 @@ jobs:
             path: ./reports
           - store_artifacts:
             path: ./reports
+
+workflow:
+  version: 2
+  test:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,27 @@
 version: 2
 
 jobs:
-  test:
+  build:
     docker:
-      -image: node: 8.9.4
+      -image: circleci/node:8.9.4-browsers
+    working_directory: ~/repo
     steps:
       - checkout
       - run: npm install
+  test:
       - run:
           name: run eslint
           command: |
-            mkdir -p ./reports
-            npx eslint ./app/ --format junit --output-file ./reports/eslint.xml
+            mkdir -p ~/reports
+            eslint ./src/ --format junit --output-file ~/reports/eslint.xml
           - store_test_results:
-            path: ./reports
+            path: ~/reports
           - store_artifacts:
-            path: ./reports
+            path: ~/reports
 
 workflow:
   version: 2
-  test:
+  build_and_test:
     jobs:
+      - build
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           keys:
           - dependencies-{{ checksum "package.json" }}
           - dependencies-
-      - run: npm install --global eslint
+      - run: npm install eslint
       - save_cache:
           paths:
             - node_modules

--- a/src/test/main.js
+++ b/src/test/main.js
@@ -1,4 +1,1 @@
 // このファイルに各種テスト用のファイルをrequireして使ってください :pray:
-var hoge = function() {
-    console.log("hoge");
-}

--- a/src/test/main.js
+++ b/src/test/main.js
@@ -1,1 +1,4 @@
 // このファイルに各種テスト用のファイルをrequireして使ってください :pray:
+var hoge = function() {
+    console.log("hoge");
+}


### PR DESCRIPTION
## やったこと
CirleCI2.0へ移行しました。
以前よりCIが走る時間が短くなっています。
## 参考にしたサイト
* https://www.viget.com/articles/using-junit-on-circleci-2-0-with-jest-and-eslint/
* https://circleci.com/docs/2.0/circleci-images/#nodejs
* https://circleci.com/docs/2.0/migrating-from-1-2/#overview